### PR TITLE
Add a new filter: default

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -534,7 +534,7 @@ exports.indexOf = function (arr, searchvalue, fromindex) {
  * @return {string|array|object}
  */
 exports.default = function(input, value) {
-  return (input.length > 0)
+  return (input && input.length > 0)
     ? toString(input)
     : toString(value);
 };


### PR DESCRIPTION
I found the filter default witch exist in the shopify document very helpful for me when i try to send a bulk emails.
It work perfect when you know your customers didn't have  same information, someone may have gender and the other may not. (or a complicated gender which they didn't want to let us know )

Oh, almost forgot but i didn't like the trailing white space in the filter.js file so i remove all of them.

Example:

``` nodejs
Dear {{ customer.name | default: "customer" }}
```

returns "Dear customer" if we don't know the name, but "Dear John" if we do.

http://docs.shopify.com/themes/liquid-basics/output#default
