### PR TITLE
Pass context as the last argument on sync filters too

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -383,6 +383,7 @@ Context.prototype.callFilter = function (method, args, callback) {
     args.push(this);
     info[1].apply(null, args);
   } else {
+    args.push(this);
     callback(null, info[1].apply(null, args));
   }
 };


### PR DESCRIPTION
The [filter documentation](https://github.com/leizongmin/tinyliquid/wiki/The-Context-Instance#set-t
he-sync-filter-contextsetfiltername-fn) says the context is always the last argument, but this was only true for async filters. This passes it on sync filters as well.