### PR TITLE
Removed spaces around included filename

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -398,7 +398,7 @@ var baseTags = {
     } else if (blocks.length === 1 &&
                !(blocks[0].substr(0, 2) === '{{' && blocks[0].substr(-2) === '}}')) {
       // filename is a string
-      filename = stripQuoteWrap(blocks[0]);
+      filename = stripQuoteWrap(blocks[0]).trim();
     } else {
       if (blocks.length >= 3 && blocks[blocks.length - 2].toLowerCase() === 'with') {
         // if include "with" syntax
@@ -420,7 +420,7 @@ var baseTags = {
         blocks = blocks.slice(i + 1);
       } else {
         // filename is a string
-        filename = stripQuoteWrap(bf);
+        filename = stripQuoteWrap(bf).trim();
         blocks = blocks.slice(1);
       }
 


### PR DESCRIPTION
When including a file with parameters authored on several lines, tinyliquid fails to properly include the file because of the line break between the file path and the first parameter.

```html
{% include component.html
  param = true
%}
```

This PR intends to fix this by simply trimming the file name before trying to read it. I checked locally, all tests are passing.